### PR TITLE
Add timestamped logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ What you will not find here is code related to gameplay implementation, such as 
 * [`graphics`](graphics.p8) - Drawing and sprite manipulation
 * [`physics`](physics.p8) - Collision functions, etc
 * [`memory`](memory.p8) - Reading, writing, manipulating memory
+* [`log`](log.p8) - Write timestamped (local time) logs to STDOUT
 
 ### Classes
 * [`vector`](vector.p8) - 2d vectors

--- a/log.p8
+++ b/log.p8
@@ -6,6 +6,18 @@ __lua__
 
 -- Depends on pico8lib/strings.p8
 
+-- P8LIBLOGTZ configures the output to either use UTC or local time.
+-- Valid values are "local" or "utc"
+local P8LIBLOGTZ = "local"
+
+-- P8LIBLOGLVL configures the logging functions to only output certain log
+-- levels.
+-- 0 - disable logging
+-- 1 - errors only
+-- 2 - warnings and errors
+-- 3 - all logs (info, warnings, and errors)
+local P8LIBLOGLVL = 3
+
 --- Log the passed in object to STDOUT
 -- The passed in object will be converted to a string and then logged with a
 -- timestamp.
@@ -13,13 +25,15 @@ __lua__
 -- @param any The object to log
 -- @return nil
 local function log (level, any)
-   local message = stat(90)
-   message = message .. "-" .. stat(91)
-   message = message .. "-" .. stat(92)
-   message = message .. " " .. stat(93)
-   message = message .. ":" .. stat(94)
-   message = message .. ":" .. stat(95)
-   printh(message .. level .. " - " .. tostr(any))
+   tz = P8LIBLOGTZ == "utc" and 80 or 90
+   seconds = stat(tz+5)
+   printh(stat(tz) .. "-" ..
+          stat(tz+1) .. "-" ..
+          stat(tz+2) .. " " ..
+          stat(tz+3) .. ":" ..
+          stat(tz+4) .. ":" ..
+          (seconds < 10 and "0" .. seconds or seconds)
+          .. " " .. level .. " - " .. tostr(any))
 end
 
 
@@ -28,21 +42,51 @@ end
 -- @param any The object to log
 -- @return nil
 local function log_info (any)
-   log("INFO", any)
+   if (P8LIBLOGLVL >= 3) log("INF", any)
 end
+
 
 --- Log the passed in object to STDOUT with the WARN tag
 -- See the `log` function for details
 -- @param any The object to log
 -- @return nil
 local function log_warn (any)
-   log("WARN", any)
+   if (P8LIBLOGLVL >= 2) log("WAR", any)
 end
+
 
 --- Log the passed in object to STDOUT with the ERR tag
 -- See the `log` function for details
 -- @param any The object to log
 -- @return nil
 local function log_err (any)
-   log("ERR", any)
+   if (P8LIBLOGLVL >= 1) log("ERR", any)
 end
+
+
+--- Example usage
+-- life = 0
+-- save_file_exists = false
+-- fps = 30
+-- P8LIBLOGLVL = 3
+-- P8LIBLOGTZ = "utc"
+-- if (life == 0) log_err("Oh no! life is zero!")
+-- if (not save_file_exists) log_warn("No save file found.")
+-- log_info("FPS:" .. fps)
+
+-- P8LIBLOGLVL = 2
+-- P8LIBLOGTZ = "local"
+-- if (life == 0) log_err("Oh no! life is zero!")
+-- if (not save_file_exists) log_warn("No save file found.")
+-- log_info("FPS:" .. fps)
+
+--
+-- Example output
+-- $ pico8 -x log.p8 
+-- RUNNING: log.p8
+-- 2023-4-16 19:44:10 ERR - Oh no! life is zero!
+-- 2023-4-16 19:44:10 WAR - No save file found.
+-- 2023-4-16 19:44:10 INF - FPS:30
+-- 2023-4-16 12:44:10 ERR - Oh no! life is zero!
+-- 2023-4-16 12:44:10 WAR - No save file found.
+

--- a/log.p8
+++ b/log.p8
@@ -6,9 +6,9 @@ __lua__
 
 -- Depends on pico8lib/strings.p8
 
--- P8LIBLOGTZ configures the output to either use UTC or local time.
--- Valid values are "local" or "utc"
-local P8LIBLOGTZ = "local"
+-- P8LIBLOGUTC configures the output to either use UTC or local time.
+-- false (default) for local time, true for UTC
+local P8LIBLOGUTC = false
 
 -- P8LIBLOGLVL configures the logging functions to only output certain log
 -- levels.
@@ -21,11 +21,11 @@ local P8LIBLOGLVL = 3
 --- Log the passed in object to STDOUT
 -- The passed in object will be converted to a string and then logged with a
 -- timestamp.
--- @param level A level prefix to prepend to the message
+-- @param prefix A prefix to prepend to the message
 -- @param any The object to log
 -- @return nil
-local function log (level, any)
-   tz = P8LIBLOGTZ == "utc" and 80 or 90
+local function log (prefix, any)
+   tz = P8LIBLOGTZ and 80 or 90
    seconds = stat(tz+5)
    printh(stat(tz) .. "-" ..
           stat(tz+1) .. "-" ..
@@ -33,7 +33,7 @@ local function log (level, any)
           stat(tz+3) .. ":" ..
           stat(tz+4) .. ":" ..
           (seconds < 10 and "0" .. seconds or seconds)
-          .. " " .. level .. " - " .. tostr(any))
+          .. " " .. prefix .. " - " .. tostr(any))
 end
 
 
@@ -69,13 +69,13 @@ end
 -- save_file_exists = false
 -- fps = 30
 -- P8LIBLOGLVL = 3
--- P8LIBLOGTZ = "utc"
+-- P8LIBLOGTZ = true
 -- if (life == 0) log_err("Oh no! life is zero!")
 -- if (not save_file_exists) log_warn("No save file found.")
 -- log_info("FPS:" .. fps)
 
 -- P8LIBLOGLVL = 2
--- P8LIBLOGTZ = "local"
+-- P8LIBLOGTZ = false
 -- if (life == 0) log_err("Oh no! life is zero!")
 -- if (not save_file_exists) log_warn("No save file found.")
 -- log_info("FPS:" .. fps)

--- a/log.p8
+++ b/log.p8
@@ -25,7 +25,7 @@ local P8LIBLOGLVL = 3
 -- @param any The object to log
 -- @return nil
 local function log (prefix, any)
-   tz = P8LIBLOGTZ and 80 or 90
+   tz = P8LIBLOGUTC and 80 or 90
    seconds = stat(tz+5)
    printh(stat(tz) .. "-" ..
           stat(tz+1) .. "-" ..
@@ -69,13 +69,13 @@ end
 -- save_file_exists = false
 -- fps = 30
 -- P8LIBLOGLVL = 3
--- P8LIBLOGTZ = true
+-- P8LIBLOGUTC = true
 -- if (life == 0) log_err("Oh no! life is zero!")
 -- if (not save_file_exists) log_warn("No save file found.")
 -- log_info("FPS:" .. fps)
 
 -- P8LIBLOGLVL = 2
--- P8LIBLOGTZ = false
+-- P8LIBLOGUTC = false
 -- if (life == 0) log_err("Oh no! life is zero!")
 -- if (not save_file_exists) log_warn("No save file found.")
 -- log_info("FPS:" .. fps)

--- a/log.p8
+++ b/log.p8
@@ -1,0 +1,48 @@
+pico-8 cartridge // http://www.pico-8.com
+version 18
+__lua__
+-- pico8lib logging library
+-- by mindfilleter
+
+-- Depends on pico8lib/strings.p8
+
+--- Log the passed in object to STDOUT
+-- The passed in object will be converted to a string and then logged with a
+-- timestamp.
+-- @param level A level prefix to prepend to the message
+-- @param any The object to log
+-- @return nil
+local function log (level, any)
+   local message = stat(90)
+   message = message .. "-" .. stat(91)
+   message = message .. "-" .. stat(92)
+   message = message .. " " .. stat(93)
+   message = message .. ":" .. stat(94)
+   message = message .. ":" .. stat(95)
+   printh(message .. level .. " - " .. tostr(any))
+end
+
+
+--- Log the passed in object to STDOUT with the INFO tag
+-- See the `log` function for details
+-- @param any The object to log
+-- @return nil
+local function log_info (any)
+   log("INFO", any)
+end
+
+--- Log the passed in object to STDOUT with the WARN tag
+-- See the `log` function for details
+-- @param any The object to log
+-- @return nil
+local function log_warn (any)
+   log("WARN", any)
+end
+
+--- Log the passed in object to STDOUT with the ERR tag
+-- See the `log` function for details
+-- @param any The object to log
+-- @return nil
+local function log_err (any)
+   log("ERR", any)
+end


### PR DESCRIPTION
log.p8 contains useful helper functions for logging timestamped messages to STDOUT. I couldn't find a way to log to STDERR unfortunately, it doesn't seem that it is supported by the pico8 API. I took a dependency on the tostr function in strings.p8 to handle stringifying tables, booleans, and other such types.

This commit also updates the README following the pattern there to add a reference to the new log.p8 file.